### PR TITLE
Add debug info to redis cleanup

### DIFF
--- a/src/Codeception/Module/Redis.php
+++ b/src/Codeception/Module/Redis.php
@@ -128,6 +128,7 @@ class Redis extends CodeceptionModule implements RequiresPackage
     public function cleanup()
     {
         try {
+            $this->debugSection('Redis', 'Performing cleanup');
             $this->driver->flushdb();
         } catch (\Exception $e) {
             throw new ModuleException(


### PR DESCRIPTION
I wanted to confirm the cleanup was happening after the module-db was doing its thing. I popped this code in locally and it verified the ordering for me. 

Figured I'd push it upstream in case others wanted to do the same thing