### PR TITLE
Allow more parameters to be sent to Predis Client

### DIFF
--- a/src/Codeception/Module/Redis.php
+++ b/src/Codeception/Module/Redis.php
@@ -83,11 +83,7 @@ class Redis extends CodeceptionModule implements RequiresPackage
     public function _initialize()
     {
         try {
-            $this->driver = new RedisDriver([
-                'host'     => $this->config['host'],
-                'port'     => $this->config['port'],
-                'database' => $this->config['database']
-            ]);
+            $this->driver = new RedisDriver($this->config);
         } catch (\Exception $e) {
             throw new ModuleException(
                 __CLASS__,

--- a/src/Codeception/Module/Redis.php
+++ b/src/Codeception/Module/Redis.php
@@ -21,10 +21,14 @@ use Predis\Client as RedisDriver;
  * * **`host`** (`string`, default `'127.0.0.1'`) - The Redis host
  * * **`port`** (`int`, default `6379`) - The Redis port
  * * **`database`** (`int`, no default) - The Redis database. Needs to be specified.
+ * * **`username`** (`string`, no default) - When ACLs are enabled on Redis >= 6.0, both username and password are required for user authentication.
+ * * **`password`** (`string`, no default) - The Redis password/secret.
  * * **`cleanupBefore`**: (`string`, default `'never'`) - Whether/when to flush the database:
  *     * `suite`: at the beginning of every suite
  *     * `test`: at the beginning of every test
  *     * Any other value: never
+ *
+ * Note: The full configuration list can be found on Predis' github.
  *
  * ### Example (`unit.suite.yml`)
  *


### PR DESCRIPTION
I had a case where I needed to provide a password to connect to Redis and the current code did not allow it.
Since everything from the Suite configuration goes to the this->config array, we can simply provide it and allow the user to set the password property
This will also allow for other specific configurations