### PR TITLE
seeInRedis compares expected value to actual value

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
 	"require": {
 		"php": "^7.4 || ^8.0",
 		"codeception/codeception": "^4.0",
-		"predis/predis": "^1.0"
+		"predis/predis": "^1.0",
+		"sebastian/comparator": "^4.0"
 	},
 	"autoload": {
 		"classmap": [

--- a/src/Codeception/Module/Redis.php
+++ b/src/Codeception/Module/Redis.php
@@ -695,6 +695,20 @@ class Redis extends Module implements RequiresPackage
             $comparatorFactory = new ComparatorFactory();
             $comparator = $comparatorFactory->getComparatorFor($value, $reply);
             $comparator->assertEquals($value, $reply);
+
+            if ($type == 'zset') {
+                /**
+                 * ArrayComparator considers out of order assoc arrays as equal
+                 * So we have to compare them as strings
+                 */
+                $replyAsString = var_export($reply, true);
+                $valueAsString = var_export($value, true);
+                $comparator = $comparatorFactory->getComparatorFor($valueAsString, $replyAsString);
+                $comparator->assertEquals($valueAsString, $replyAsString);
+            }
+            // If comparator things that values are equal, then we trust it
+            // This shouldn't happen in practice.
+            return true;
         }
 
         return $result;

--- a/tests/unit/Codeception/Module/RedisTest.php
+++ b/tests/unit/Codeception/Module/RedisTest.php
@@ -956,12 +956,15 @@ final class RedisTest extends Unit
     public function testSeeInRedisNonExistingKeyWithoutValue()
     {
         $this->shouldFail();
+        $this->expectExceptionMessage('Cannot find key "doesnotexist"');
         $this->module->seeInRedis('doesnotexist');
     }
 
     public function testSeeInRedisNonExistingKeyWithValue()
     {
         $this->shouldFail();
+        $this->expectExceptionMessageMatches('/^Cannot find key "doesnotexist"' .
+            "\n" . 'Failed asserting that false is true.$/');
         $this->module->seeInRedis(
             'doesnotexist',
             'some value'
@@ -994,6 +997,7 @@ final class RedisTest extends Unit
     public function testSeeInRedisExistingStringWithIncorrectValue()
     {
         $this->shouldFail();
+        $this->expectExceptionMessage('Value of key "test:string" does not match expected value');
         $this->module->seeInRedis(
             self::$keys['string']['name'],
             'incorrect value'
@@ -1024,6 +1028,7 @@ final class RedisTest extends Unit
     public function testSeeInRedisExistingListWithIncorrectValue()
     {
         $this->shouldFail();
+        $this->expectExceptionMessage('Value of key "test:list" does not match expected value');
         $this->module->seeInRedis(
             self::$keys['list']['name'],
             ['incorrect', 'value']
@@ -1053,6 +1058,7 @@ final class RedisTest extends Unit
     public function testSeeInRedisExistingSetWithIncorrectValue()
     {
         $this->shouldFail();
+        $this->expectExceptionMessage('Value of key "test:set" does not match expected value');
         $this->module->seeInRedis(
             self::$keys['set']['name'],
             ['incorrect', 'value']
@@ -1092,6 +1098,7 @@ final class RedisTest extends Unit
     public function testSeeInRedisExistingZSetWithIncorrectValue()
     {
         $this->shouldFail();
+        $this->expectExceptionMessage('Value of key "test:zset" does not match expected value');
         $this->module->seeInRedis(
             self::$keys['zset']['name'],
             ['incorrect' => 1, 'value' => 2]
@@ -1121,6 +1128,7 @@ final class RedisTest extends Unit
     public function testSeeInRedisExistingHashWithIncorrectValue()
     {
         $this->shouldFail();
+        $this->expectExceptionMessage('Value of key "test:hash" does not match expected value');
         $this->module->seeInRedis(
             self::$keys['hash']['name'],
             ['incorrect' => 'value']


### PR DESCRIPTION
I used `$I->seeInRedis($key, $expectedValue)` in my project and it failed with very disappointing message.

> Cannot find key "doesnotexist" with the provided value.


I expected to see a diff between expected value and actual value, like the one displayed by `seeResponseMatchesJsonType`
So I implemented it myself.

Examples of output with diff:


```

---------
3) RedisTest: See in redis existing string with incorrect value
 Test  tests/unit/Codeception/Module/RedisTest.php:testSeeInRedisExistingStringWithIncorrectValue
Value of key "test:string" does not match expected value
- Expected | + Actual
@@ @@
-'incorrect value'
+'hello'
#1  /.../module-redis/src/Codeception/Module/Redis.php:688
#2  /.../module-redis/src/Codeception/Module/Redis.php:454
#3  /.../module-redis/tests/unit/Codeception/Module/RedisTest.php:1000
#4  /.../module-redis/vendor/bin/codecept(21) : eval()'d code:6
#5  /.../module-redis/vendor/bin/codecept:21

---------
4) RedisTest: See in redis existing list with correct value different order
 Test  tests/unit/Codeception/Module/RedisTest.php:testSeeInRedisExistingListWithCorrectValueDifferentOrder
Value of key "test:list" does not match expected value
- Expected | + Actual
@@ @@
Array (
-    0 => 'loulou'
+    0 => 'riri'
1 => 'fifi'
-    2 => 'riri'
+    2 => 'loulou'
)
#1  /.../module-redis/src/Codeception/Module/Redis.php:688
#2  /.../module-redis/src/Codeception/Module/Redis.php:454
#3  /.../module-redis/tests/unit/Codeception/Module/RedisTest.php:1021
#4  /.../module-redis/vendor/bin/codecept(21) : eval()'d code:6
#5  /.../module-redis/vendor/bin/codecept:21

---------
5) RedisTest: See in redis existing list with incorrect value
 Test  tests/unit/Codeception/Module/RedisTest.php:testSeeInRedisExistingListWithIncorrectValue
Value of key "test:list" does not match expected value
- Expected | + Actual
@@ @@
Array (
-    0 => 'incorrect'
-    1 => 'value'
+    0 => 'riri'
+    1 => 'fifi'
+    2 => 'loulou'
)
#1  /.../module-redis/src/Codeception/Module/Redis.php:688
#2  /.../module-redis/src/Codeception/Module/Redis.php:454
#3  /.../module-redis/tests/unit/Codeception/Module/RedisTest.php:1030
#4  /.../module-redis/vendor/bin/codecept(21) : eval()'d code:6
#5  /.../module-redis/vendor/bin/codecept:21

---------
6) RedisTest: See in redis existing set with incorrect value
 Test  tests/unit/Codeception/Module/RedisTest.php:testSeeInRedisExistingSetWithIncorrectValue
Value of key "test:set" does not match expected value
- Expected | + Actual
@@ @@
Array (
-    0 => 'incorrect'
-    1 => 'value'
+    0 => 'dewey'
+    1 => 'huey'
+    2 => 'louie'
)
#1  /.../module-redis/src/Codeception/Module/Redis.php:688
#2  /.../module-redis/src/Codeception/Module/Redis.php:454
#3  /.../module-redis/tests/unit/Codeception/Module/RedisTest.php:1059
#4  /.../module-redis/vendor/bin/codecept(21) : eval()'d code:6
#5  /.../module-redis/vendor/bin/codecept:21

---------
7) RedisTest: See in redis existing z set with correct value without scores
 Test  tests/unit/Codeception/Module/RedisTest.php:testSeeInRedisExistingZSetWithCorrectValueWithoutScores
Value of key "test:zset" does not match expected value
- Expected | + Actual
@@ @@
Array (
-    0 => 0.0
-    1 => 0.0
-    2 => 0.0
+    'juanito' => 1.0
+    'jorgito' => 2.0
+    'jaimito' => 3.0
)
#1  /.../module-redis/src/Codeception/Module/Redis.php:688
#2  /.../module-redis/src/Codeception/Module/Redis.php:454
#3  /.../module-redis/tests/unit/Codeception/Module/RedisTest.php:1080
#4  /.../module-redis/vendor/bin/codecept(21) : eval()'d code:6
#5  /.../module-redis/vendor/bin/codecept:21

---------
8) RedisTest: See in redis existing z set with correct value different order
 Test  tests/unit/Codeception/Module/RedisTest.php:testSeeInRedisExistingZSetWithCorrectValueDifferentOrder
Cannot find key "test:zset" with the provided value
Failed asserting that false is true.
#1  /.../module-redis/src/Codeception/Module/Redis.php:455
#2  /.../module-redis/tests/unit/Codeception/Module/RedisTest.php:1089
#3  /.../module-redis/vendor/bin/codecept(21) : eval()'d code:6
#4  /.../module-redis/vendor/bin/codecept:21

---------
9) RedisTest: See in redis existing z set with incorrect value
 Test  tests/unit/Codeception/Module/RedisTest.php:testSeeInRedisExistingZSetWithIncorrectValue
Value of key "test:zset" does not match expected value
- Expected | + Actual
@@ @@
Array (
-    'incorrect' => 1.0
-    'value' => 2.0
+    'juanito' => 1.0
+    'jorgito' => 2.0
+    'jaimito' => 3.0
)
#1  /.../module-redis/src/Codeception/Module/Redis.php:688
#2  /.../module-redis/src/Codeception/Module/Redis.php:454
#3  /.../module-redis/tests/unit/Codeception/Module/RedisTest.php:1098
#4  /.../module-redis/vendor/bin/codecept(21) : eval()'d code:6
#5  /.../module-redis/vendor/bin/codecept:21

---------
10) RedisTest: See in redis existing hash with incorrect value
 Test  tests/unit/Codeception/Module/RedisTest.php:testSeeInRedisExistingHashWithIncorrectValue
Value of key "test:hash" does not match expected value
- Expected | + Actual
@@ @@
Array (
-    'incorrect' => 'value'
+    'Tick' => '1'
+    'Trick' => 'dewey'
+    'Track' => '42'
)
#1  /.../module-redis/src/Codeception/Module/Redis.php:688
#2  /.../module-redis/src/Codeception/Module/Redis.php:454
#3  /.../module-redis/tests/unit/Codeception/Module/RedisTest.php:1127
#4  /.../module-redis/vendor/bin/codecept(21) : eval()'d code:6
#5  /.../module-redis/vendor/bin/codecept:21
```