### PR TITLE
Allow sebastian/comparator ^6.0 to support PHPUnit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"php": "^8.0",
 		"codeception/codeception": "^5.0",
 		"predis/predis": "^1.1 | ^2.0",
-		"sebastian/comparator": "^4.0 | ^5.0"
+		"sebastian/comparator": "^4.0 | ^5.0 | ^6.0"
 	},
 	"autoload": {
 		"classmap": [


### PR DESCRIPTION
It seems there is no BC break in that version.