### PR TITLE
Test against PHP 8.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2]
+        php: [8.0, 8.1, 8.2, 8.3, 8.4]
 
     steps:
     - name: Checkout code

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Redis module for Codeception
 
 ## Requirements
 
-* `PHP 7.4` or higher.
+* `PHP 8.0` or higher.
 
 ## Installation
 

--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -1,2 +1,2 @@
-error_level: "E_ALL | E_STRICT"
+error_level: "E_ALL"
 class_name: UnitTester


### PR DESCRIPTION
The usage of the `E_STRICT` constant is removed because it is deprecated in PHP 8.4: https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant